### PR TITLE
Add destroy mode of delete()

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,11 @@ client.update(column="name", value="Peter", data=dict(score=120))
 More information can be found [here](https://docs.sheetsu.com/#delete)
 
 ````python
-# Delete "Peter" user from default sheet
+# Delete "Peter" user from default sheet (but leave empty row)
 client.delete(column="name", value="Peter")
+
+# Delete "Susan" user from default sheet, and remove row (moving later rows up)
+client.delete(column="name", value="Susan", destroy="true")
 ````
 
 ## Development

--- a/sheetsu/core/core.py
+++ b/sheetsu/core/core.py
@@ -4,7 +4,7 @@ import requests
 import re
 from requests.auth import HTTPBasicAuth
 
-from sheetsu.exceptions import UnknownRequestMethod
+from sheetsu.exceptions import UnknownRequestMethod, UnexpectedResponseCode
 
 import logging
 logger = logging.getLogger('sheetsu.' + __name__)
@@ -70,7 +70,11 @@ class Resource(object):
                          "".format(r.status_code, r.text, url))
             return
 
-        if method == 'delete':
-            return None
+        if method == 'delete' and len(kwargs['data']) == 0:
+            ## this is a "clear"-style delete - no return data is expected
+            if r.status_code == 204: # success
+                return None
+            else:
+                raise UnexpectedResponseCode
         else:
             return json.loads(r.content)

--- a/sheetsu/core/delete.py
+++ b/sheetsu/core/delete.py
@@ -1,3 +1,5 @@
+import json
+
 from .core import Resource
 
 
@@ -10,12 +12,19 @@ class DeleteResource(Resource):
         :return:
         """
         url = self.spreadsheet_id
+
         if kwargs.get('sheet'):
             url += "/sheets/" + kwargs.pop('sheet')
 
-        if kwargs.get('column') and kwargs.get('value'):
-            url += "/" + kwargs.pop('column') + "/" + kwargs.pop('value')
+        # If destroy=true, the row is removed from the sheet; else the data is
+        # cleared but the empty row kept in the sheet.
+        if kwargs.get('destroy') and kwargs.pop('destroy') == 'true':
+            data = {}
+            data[kwargs.pop('column')] = kwargs.pop('value')            
+            payload = dict(url=url, method="delete", data=json.dumps(data))
+        else:
+            if kwargs.get('column') and kwargs.get('value'):
+                url += "/" + kwargs.pop('column') + "/" + kwargs.pop('value')
+            payload = dict(url=url, method="delete")
 
-        payload = dict(url=url, method="delete")
         return super(DeleteResource, self).__call__(**payload)
-

--- a/sheetsu/exceptions.py
+++ b/sheetsu/exceptions.py
@@ -1,3 +1,7 @@
 class UnknownRequestMethod(Exception):
     """Exception raised once unexpected HTTP request code"""
     pass
+
+class UnexpectedResponseCode(Exception):
+    """Raised when unexpected HTTP response code is received"""
+    pass

--- a/sheetsu/tests/test_delete.py
+++ b/sheetsu/tests/test_delete.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from sheetsu import SheetsuClient
-
+from sheetsu.exceptions import UnexpectedResponseCode
 
 class SheetsuApiDeleteTestCase(TestCase):
     """"""
@@ -18,8 +18,8 @@ class SheetsuApiDeleteTestCase(TestCase):
         }
 
     @patch("requests.sessions.Session.request")
-    def test_delete_success(self, mock):
-        """Ensure that DELETE works properlly """
+    def test_delete_clear_success(self, mock):
+        """Ensure that DELETE works properly in "clear" mode"""
         mock.return_value = MagicMock(status_code=204)
         
         client = SheetsuClient(**self.kwargs)
@@ -27,11 +27,44 @@ class SheetsuApiDeleteTestCase(TestCase):
         self.assertIsNone(response)
 
     @patch("requests.sessions.Session.request")
-    def test_delete_with_sheet_success(self, mock):
-        """Ensure that DELETE works properlly """
+    def test_delete_clear_with_sheet_success(self, mock):
+        """Ensure that DELETE works properly in "clear" mode"""
         mock.return_value = MagicMock(status_code=204)
-
+        
         client = SheetsuClient(**self.kwargs)
         response = client.delete(sheet="Sheet1", column="name", value="Meg")
         self.assertIsNone(response)
 
+    @patch("requests.sessions.Session.request")
+    def test_delete_destroy_with_sheet_success(self, mock):
+        """Ensure that DELETE works properly in "destroy" mode"""
+        mock.return_value = MagicMock(status_code=200, content=json.dumps([
+            {'id': '5', 'name': 'Stewie', 'score': '72'}
+        ]))
+
+        client = SheetsuClient(**self.kwargs)
+        response = client.delete(column="name", value="Meg", destroy="true")
+        self.assertEqual(response, [
+            {'id': '5', 'name': 'Stewie', 'score': '72'}
+        ])
+
+    @patch("requests.sessions.Session.request")
+    def test_delete_destroy_invalid_with_sheet_success(self, mock):
+        """Ensure that DELETE works properly with bad "destroy" parameter"""
+        mock.return_value = MagicMock(status_code=204)
+
+        client = SheetsuClient(**self.kwargs)
+        response = client.delete(sheet="Sheet1", column="name", value="Meg", destroy="invalid")
+        self.assertIsNone(response)
+
+    @patch("requests.sessions.Session.request")
+    def test_delete_clear_with_bad_response_fail(self, mock):
+        """Ensure that DELETE in clear-mode raises an exception when it doesn't get a 204"""
+        mock.return_value = MagicMock(status_code=205)
+
+        client = SheetsuClient(**self.kwargs)
+        with self.assertRaises(UnexpectedResponseCode):
+            response = client.delete(sheet="Sheet1", column="name", value="Meg")
+
+
+    


### PR DESCRIPTION
Sheetsu supports two types of delete() - one that they call "clear", and one called "destroy". "Clear" leaves the removed row in place (empty), "delete" removes the row and moves up other rows to close in the gap in the sheet.

This change adds support for the "destroy" mode to sheetsu-python. I needed it for my project, but thought it'd be generally useful. 

You might not love the way I exposed the option (via a special keyword arg on delete()) - feel free to suggest a different approach or change it as you see fit. 